### PR TITLE
fix: add .storybook to exclude list

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,6 +13,7 @@ const testFileExtensions = defaultExtensions
   .join(",");
 
 export const defaultExclude = [
+  ".storybook/**",
   "coverage/**",
   "packages/*/test{,s}/**",
   "**/*.d.ts",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.2-canary.2.726749d.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-coverage@0.0.2-canary.2.726749d.0
  # or 
  yarn add @storybook/addon-coverage@0.0.2-canary.2.726749d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
