### PR TITLE
Fix: update babel targets to support Storybook 7.0

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,6 +1,14 @@
 module.exports = {
   presets: [
-    "@babel/preset-env",
+    [
+      "@babel/preset-env",
+      {
+        shippedProposals: true,
+        useBuiltIns: "usage",
+        corejs: "3",
+        targets: { node: "14" },
+      },
+    ],
     "@babel/preset-typescript",
     "@babel/preset-react",
   ],
@@ -10,7 +18,11 @@ module.exports = {
         [
           "@babel/preset-env",
           {
+            shippedProposals: true,
+            useBuiltIns: "usage",
+            corejs: "3",
             modules: false,
+            targets: { chrome: "100" },
           },
         ],
       ],


### PR DESCRIPTION
Storybook 7 changed its targets to modern browsers so it does not contain polyfills like runtimeGenerator etc.
The addon now has to account for that in order to work properly in Storybook 7.0

**Breaking changes:**
CJS targets node 14
ESM now targets modern browsers (chrome 100)