### PR TITLE
fix scenario where plugins do not exist

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -7,6 +7,7 @@ export const babel = async (
   babelConfig: TransformOptions,
   options: Options & AddonOptions
 ) => {
+  babelConfig.plugins ||= [];
   babelConfig.plugins.push([
     "istanbul",
     {


### PR DESCRIPTION
The preset assumed babel configs always had a `plugins` field. Now it doesn't :D