### PR TITLE
Docs - fix cwd default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The available options are as follows:
 
 | Option name | Description                                                                              | Type            | Default                                                                          |
 | ----------- | ---------------------------------------------------------------------------------------- | --------------- | -------------------------------------------------------------------------------- |
-| `cwd`       | Set the working directory                                                                | `String`        | `['**']`                                                                         |
+| `cwd`       | Set the working directory                                                                | `String`        | `process.cwd()`                                                                         |
 | `include`   | See [here](https://github.com/istanbuljs/nyc#selecting-files-for-coverage) for more info | `Array<String>` | `['**']`                                                                         |
 | `exclude`   | See [here](https://github.com/istanbuljs/nyc#selecting-files-for-coverage) for more info | `Array<String>` | [list](https://github.com/storybookjs/addon-coverage/blob/main/src/constants.js) |
 | `extension` | List of extensions that nyc should attempt to handle in addition to `.js`                | `Array<String>` | `['.js', '.cjs', '.mjs', '.ts', '.tsx', '.jsx', '.vue', '.svelte]`               |


### PR DESCRIPTION
nyc will default to `process.cwd()` when cwd is not set

https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/lib/config-util.js#L12