### PR TITLE
Fix: Handle scenario where rawSourceMap is a string

### DIFF
--- a/src/loader/webpack5-istanbul-loader.ts
+++ b/src/loader/webpack5-istanbul-loader.ts
@@ -25,7 +25,8 @@ type RawSourceMap = {
   names?: string[];
 };
 
-function sanitizeSourceMap(rawSourceMap: RawSourceMap): RawSourceMap {
+function sanitizeSourceMap(rawSourceMap: RawSourceMap | string): RawSourceMap {
+  if (typeof rawSourceMap === 'string') return JSON.parse(rawSourceMap);
   const { sourcesContent, ...sourceMap } = rawSourceMap ?? {};
 
   // JSON parse/stringify trick required for istanbul to accept the SourceMap


### PR DESCRIPTION
Fixed the problem that rawSourceMap may be a string, causing the coverage plug-in to report an error

✅ Closes: #32