### PR TITLE
Fix sourcemap generation for Webpack5 projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "convert-source-map": "^2.0.0",
     "espree": "^9.6.1",
     "istanbul-lib-instrument": "^6.0.1",
-    "source-map": "^0.7.4",
     "test-exclude": "^6.0.0",
     "vite-plugin-istanbul": "^3.0.1"
   }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.4--canary.42.041aa23.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-coverage@1.0.4--canary.42.041aa23.0
  # or 
  yarn add @storybook/addon-coverage@1.0.4--canary.42.041aa23.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
