### PR TITLE
fix: Handling of rawSourceMap string type in webpack5-istanbul-loader

### DIFF
--- a/src/loader/webpack5-istanbul-loader.ts
+++ b/src/loader/webpack5-istanbul-loader.ts
@@ -25,7 +25,7 @@ type RawSourceMap = {
 };
 
 function sanitizeSourceMap(rawSourceMap: RawSourceMap | string): RawSourceMap {
-  return rawSourceMap === "string" ? JSON.parse(rawSourceMap) : rawSourceMap;
+  return typeof rawSourceMap === "string" ? JSON.parse(rawSourceMap) : rawSourceMap;
 }
 
 export default function (


### PR DESCRIPTION
Hi Team,

I noticed a regression in the latest version v1.0.4. The same issue was previously reported here https://github.com/storybookjs/addon-coverage/issues/32, and fixed in https://github.com/storybookjs/addon-coverage/pull/33. However, it was reintroduced as part of [Fix sourcemap generation for Webpack5 projects](https://github.com/storybookjs/addon-coverage/pull/42/files#diff-bf8912f263fb99ddb75893bcc11ed6800288dfd57de2fdd67337b8b74442044cR28).

I hope you are okay to merge this patch and cut a bugfix release when you get a chance, please.

Thank you kindly,
Mike